### PR TITLE
Update template to suit current version of graphql_helix and svelteKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm init svelte@next
 
 Once that is set up, run this command in your project directory to set up GraphQL:
 ```sh
-npx svelte-add graphql
+npx svelte-add graphql-server
 ```
 
 After the preset runs,

--- a/templates/src/routes/graphql.ts
+++ b/templates/src/routes/graphql.ts
@@ -1,16 +1,17 @@
-import type { RequestHandler, Response } from "@sveltejs/kit";
-import { getGraphQLParameters } from "graphql-helix/dist/get-graphql-parameters.js";
-import { processRequest } from "graphql-helix/dist/process-request.js";
-import { renderGraphiQL } from "graphql-helix/dist/render-graphiql.js";
-import { shouldRenderGraphiQL } from "graphql-helix/dist/should-render-graphiql.js";
-
+import { RequestHandler, Response } from "@sveltejs/kit";
+import {
+    getGraphQLParameters,
+    processRequest,
+    renderGraphiQL,
+    shouldRenderGraphiQL
+} from "graphql-helix";
 import { createSchema, defaultQuery } from "../graphql/schema";
 
 const schemaPromise = createSchema();
 
 const respond = async (request): Promise<Response> => {
 	// Workaround for a bug with body parsing in SvelteKit
-	if (typeof request.body === "string") request.body = JSON.parse(request.body);
+	// if (typeof request.body === "string") request.body = JSON.parse(request.body);
 
 	if (shouldRenderGraphiQL(request)) return {
 		body: renderGraphiQL({
@@ -51,8 +52,8 @@ const respond = async (request): Promise<Response> => {
 	};
 };
 
-export const del: RequestHandler = ({ body, headers, query }) => respond({ body, headers, method: "DELETE", query });
-export const get: RequestHandler = ({ body, headers, query }) => respond({ body, headers, method: "GET", query });
-export const head: RequestHandler = ({ body, headers, query }) => respond({ body, headers, method: "HEAD", query });
-export const post: RequestHandler = ({ body, headers, query }) => respond({ body, headers, method: "POST", query });
-export const put: RequestHandler = ({ body, headers, query }) => respond({ body, headers, method: "PUT", query });
+export const del: RequestHandler = ({ body, headers, method, url }) => respond({ body, headers, method, query: url.searchParams });
+export const get: RequestHandler = ({ body, headers, method, url }) => respond({ body, headers, method, query: url.searchParams });
+export const head: RequestHandler = ({ body, headers, method, url }) => respond({ body, headers, method, query: url.searchParams });
+export const post: RequestHandler = ({ body, headers, method, url }) => respond({ body, headers, method, query: url.searchParams });
+export const put: RequestHandler = ({ body, headers, method, url }) => respond({ body, headers, method, query: url.searchParams });


### PR DESCRIPTION
Hi,

First, thanks very much for the template, which is quite helpful as a start point when
working with GraphQL and SvelteKit.

Try to use the template to integrate GraphQL with SvelteKit, but failed to do so by
following the introduction. And find out that `npx svelte-add graphql-server` is the
proper command to user rather than `npx svelte-add graphql` list in the introduction.

After successfully integrated the template with my proj, found that the example graphql
server doesn't work as it should be, due to recent updating of graphql-helix and svelteKit.
The PR aims to match the example server `graphql.ts` and current version of those pkgs.

Best,